### PR TITLE
Add some infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ debug.test
 *.out
 
 .glide/
+
+/exchangerates
+/exchangeratesd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: go
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+default: build
+
+build:
+	go build ./cmd/exchangerates
+	go build ./cmd/exchangeratesd
+
+test:
+	go test $$(go list ./... | grep -v vendor)
+
+.PHONY: build test


### PR DESCRIPTION
This commit adds a `Makefile`. By default, it compiles the executables
from `cmd/`. There is an additional `test` task that runs all tests,
excluding those in `vendor/`.

Second, the Travis CI config will run `make test` by default now. This
prevents the tests in `vendor/` from being run.

We also ignore executables in `.gitignore`.